### PR TITLE
Fix: incorrect conversion in fromString() method for QMinute, QSecond, QTime

### DIFF
--- a/src/main/java/com/exxeleron/qjava/QMinute.java
+++ b/src/main/java/com/exxeleron/qjava/QMinute.java
@@ -147,7 +147,7 @@ public final class QMinute implements DateTime, Serializable {
             final String[] parts = date.split(":");
             final int hours = Integer.parseInt(parts[0]);
             final int minutes = Integer.parseInt(parts[1]);
-            return new QMinute((minutes + 60 * Math.abs(hours)) * (hours > 0 ? 1 : -1));
+            return new QMinute((minutes + 60 * Math.abs(hours)) * ('-' == date.charAt(0) ? -1 : 1));
         } catch ( final Exception e ) {
             throw new IllegalArgumentException("Cannot parse QMinute from: " + date, e);
         }

--- a/src/main/java/com/exxeleron/qjava/QSecond.java
+++ b/src/main/java/com/exxeleron/qjava/QSecond.java
@@ -149,7 +149,7 @@ public final class QSecond implements DateTime, Serializable {
             final int hours = Integer.parseInt(parts[0]);
             final int minutes = Integer.parseInt(parts[1]);
             final int seconds = Integer.parseInt(parts[2]);
-            return new QSecond((seconds + 60 * minutes + 3600 * Math.abs(hours)) * (hours > 0 ? 1 : -1));
+            return new QSecond((seconds + 60 * minutes + 3600 * Math.abs(hours)) * ('-' == date.charAt(0) ? -1 : 1));
         } catch ( final Exception e ) {
             throw new IllegalArgumentException("Cannot parse QSecond from: " + date, e);
         }

--- a/src/main/java/com/exxeleron/qjava/QTime.java
+++ b/src/main/java/com/exxeleron/qjava/QTime.java
@@ -149,7 +149,7 @@ public final class QTime implements DateTime, Serializable {
             final int minutes = Integer.parseInt(parts[1]);
             final int seconds = Integer.parseInt(parts[2]);
             final int millis = Integer.parseInt(parts[3]);
-            return new QTime((millis + 1000 * seconds + 60000 * minutes + 3600000 * Math.abs(hours)) * (hours > 0 ? 1 : -1));
+            return new QTime((millis + 1000 * seconds + 60000 * minutes + 3600000 * Math.abs(hours)) * ('-' == date.charAt(0) ? -1 : 1));
         } catch ( final Exception e ) {
             throw new IllegalArgumentException("Cannot parse QTime from: " + date, e);
         }

--- a/src/test/java/com/exxeleron/qjava/TestDateTime.java
+++ b/src/test/java/com/exxeleron/qjava/TestDateTime.java
@@ -166,6 +166,7 @@ public class TestDateTime {
     public void testQMinuteToString() {
         assertEquals("00:00", new QMinute(0).toString());
         assertEquals("13:30", new QMinute(810).toString());
+        assertEquals("-13:30", new QMinute(-810).toString());
         assertEquals("23:59", new QMinute(1439).toString());
 
         assertEquals("-13:30", new QMinute(-810).toString());
@@ -177,6 +178,8 @@ public class TestDateTime {
     @Test
     public void testQMinuteFromString() {
         assertEquals(new QMinute(0), QMinute.fromString("00:00"));
+        assertEquals(new QMinute(12), QMinute.fromString("00:12"));
+        assertEquals(new QMinute(-12), QMinute.fromString("-00:12"));
         assertEquals(new QMinute(810), QMinute.fromString("13:30"));
         assertEquals(new QMinute(1439), QMinute.fromString("23:59"));
 
@@ -270,6 +273,7 @@ public class TestDateTime {
     public void testQSecondToString() {
         assertEquals("00:00:00", new QSecond(0).toString());
         assertEquals("13:30:13", new QSecond(48613).toString());
+        assertEquals("-13:30:13", new QSecond(-48613).toString());
         assertEquals("23:59:59", new QSecond(86399).toString());
 
         assertEquals("51:46:39", new QSecond(186399).toString());
@@ -281,6 +285,8 @@ public class TestDateTime {
     @Test
     public void testQSecondFromString() {
         assertEquals(new QSecond(0), QSecond.fromString("00:00:00"));
+        assertEquals(new QSecond(70), QSecond.fromString("00:01:10"));
+        assertEquals(new QSecond(-70), QSecond.fromString("-00:01:10"));
         assertEquals(new QSecond(48613), QSecond.fromString("13:30:13"));
         assertEquals(new QSecond(86399), QSecond.fromString("23:59:59"));
 
@@ -321,6 +327,7 @@ public class TestDateTime {
     @Test
     public void testQTimeToString() {
         assertEquals("00:00:00.000", new QTime(0).toString());
+        assertEquals("-13:30:13.000", new QTime(-48613000).toString());
         assertEquals("13:30:13.000", new QTime(48613000).toString());
         assertEquals("23:59:59.001", new QTime(86399001).toString());
 
@@ -334,6 +341,8 @@ public class TestDateTime {
     public void testQTimeFromString() {
         assertEquals(new QTime(48613000), QTime.fromString("13:30:13.000"));
         assertEquals(new QTime(0), QTime.fromString("00:00:00.000"));
+        assertEquals(new QTime(10000), QTime.fromString("00:00:10.000"));
+        assertEquals(new QTime(-10000), QTime.fromString("-00:00:10.000"));
         assertEquals(new QTime(86399000), QTime.fromString("23:59:59.000"));
 
         assertEquals(new QTime(186399001), QTime.fromString("51:46:39.001"));


### PR DESCRIPTION
Factory method fromString yielded invalid behavior while creating QMinute, QSecond, QTime with `hour` part equal to 0.